### PR TITLE
fix: Build fix + format

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -8,17 +8,19 @@ We have a quick list of common questions to get you started engaging with this p
 [our documentation](https://github.com/changesets/changesets/blob/main/docs/common-questions.md)
 
 # Usage
+
 1. `npx changeset` to create a changeset
 
-2. Select change type: 
+2. Select change type:
+
 ```
-Major: 
+Major:
 - Describes when to use a major change, focusing on breaking changes.
 
-Minor: 
+Minor:
 - Describes when to use a minor change, focusing on new features that are backward compatible.
 
-Patch: 
+Patch:
 - Describes when to use a patch change, focusing on bug fixes and small improvements.
 ```
 
@@ -31,5 +33,6 @@ Patch:
 9. After reviewing, merge the `Version Packages` PR on Github, the package version is then updated and published to npm.
 
 Notes:
+
 - The `Version Packages` is automatically updated with the latest changeset(s).
 - The `Version Packages` will only update the package versions and publish to npm, not the actual code.

--- a/.changeset/breezy-penguins-cover.md
+++ b/.changeset/breezy-penguins-cover.md
@@ -1,0 +1,5 @@
+---
+"@babylonlabs-io/bbn-wallet-connect": patch
+---
+
+fix type long import build error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,14 @@
+name: ci
+
+on:
+  pull_request:
+    branches:
+      - "**"
+
+jobs:
+  lint_test:
+    uses: babylonlabs-io/.github/.github/workflows/reusable_node_lint_test.yml@v0.3.0
+    with:
+      run-build: true
+      # uncomment when tests are available
+      # run-unit-tests: true

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -11,7 +11,7 @@
 
     /* Bundler Resolution */
     "moduleResolution": "Bundler",
-    "allowSyntheticDefaultImports": false,
+    "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "noImplicitAny": true,
     "isolatedModules": true,


### PR DESCRIPTION
1. Fixes the

```
Module '"/home/runner/work/bbn-wallet-connect/bbn-wallet-connect/node_modules/@types/long/index"' can only be default-imported using the 'allowSyntheticDefaultImports' flag
```

2. Adds the CI that builds the project
3. Formats the codebase