### PR TITLE
feat: Keplr offline signer, minimize interface

### DIFF
--- a/.changeset/big-eggs-attack.md
+++ b/.changeset/big-eggs-attack.md
@@ -1,0 +1,5 @@
+---
+"@babylonlabs-io/bbn-wallet-connect": patch
+---
+
+Keplr offline signer, minimize interface

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,5 +1,4 @@
-import type { SigningStargateClient, SigningStargateClientOptions } from "@cosmjs/stargate";
-import { ChainInfo } from "@keplr-wallet/types";
+import { ChainInfo, OfflineAminoSigner, OfflineDirectSigner } from "@keplr-wallet/types";
 import { ComponentType } from "react";
 
 export type Fees = {
@@ -257,15 +256,23 @@ export interface IBBNProvider extends IProvider {
   getPublicKeyHex(): Promise<string>;
 
   /**
-   * Gets the signing stargate client.
-   * @returns A promise that resolves to the signing stargate client.
+   * Gets the name of the wallet provider.
+   * @returns A promise that resolves to the name of the wallet provider.
    */
-  getSigningStargateClient(options?: SigningStargateClientOptions): Promise<SigningStargateClient>;
-  /**
-   * Gets the balance of the connected wallet.
-   * @param searchDenom - The denomination to search for in the wallet's balance.
-   * @returns A promise that resolves to the balance of the connected wallet.
-   */
+  getWalletProviderName(): Promise<string>;
 
-  getBalance(searchDenom: string): Promise<bigint>;
+  /**
+   * Gets the icon URL of the wallet provider.
+   * @returns A promise that resolves to the icon URL of the wallet provider.
+   */
+  getWalletProviderIcon(): Promise<string>;
+
+  /**
+   * Retrieves an offline signer that supports both Amino and Direct signing methods.
+   * This signer is used for signing transactions offline before broadcasting them to the network.
+   *
+   * @returns {Promise<OfflineAminoSigner & OfflineDirectSigner>} A promise that resolves to a signer supporting both Amino and Direct signing
+   * @throws {Error} If wallet connection is not established or signer cannot be retrieved
+   */
+  getOfflineSigner(): Promise<OfflineAminoSigner & OfflineDirectSigner>;
 }

--- a/src/core/wallets/bbn/BBNProvider.ts
+++ b/src/core/wallets/bbn/BBNProvider.ts
@@ -1,4 +1,4 @@
-import type { SigningStargateClient, SigningStargateClientOptions } from "@cosmjs/stargate";
+import { OfflineAminoSigner, OfflineDirectSigner } from "@keplr-wallet/types";
 
 import { IBBNProvider } from "@/core/types";
 
@@ -23,14 +23,23 @@ export abstract class BBNProvider implements IBBNProvider {
   abstract getPublicKeyHex(): Promise<string>;
 
   /**
-   * Gets the signing stargate client.
-   * @returns A promise that resolves to the signing stargate client.
+   * Gets the name of the wallet provider.
+   * @returns A promise that resolves to the name of the wallet provider.
    */
-  abstract getSigningStargateClient(options?: SigningStargateClientOptions): Promise<SigningStargateClient>;
+  abstract getWalletProviderName(): Promise<string>;
+
   /**
-   * Gets the balance of the connected wallet.
-   * @param searchDenom - The denomination to search for in the wallet's balance.
-   * @returns A promise that resolves to the balance of the connected wallet.
+   * Gets the icon URL of the wallet provider.
+   * @returns A promise that resolves to the icon URL of the wallet provider.
    */
-  abstract getBalance(searchDenom: string): Promise<bigint>;
+  abstract getWalletProviderIcon(): Promise<string>;
+
+  /**
+   * Retrieves an offline signer that supports both Amino and Direct signing methods.
+   * This signer is used for signing transactions offline before broadcasting them to the network.
+   *
+   * @returns {Promise<OfflineAminoSigner & OfflineDirectSigner>} A promise that resolves to a signer supporting both Amino and Direct signing
+   * @throws {Error} If wallet connection is not established or signer cannot be retrieved
+   */
+  abstract getOfflineSigner(): Promise<OfflineAminoSigner & OfflineDirectSigner>;
 }

--- a/src/core/wallets/bbn/keplr/provider.ts
+++ b/src/core/wallets/bbn/keplr/provider.ts
@@ -16,6 +16,7 @@ export class KeplrProvider extends BBNProvider {
   private walletInfo: WalletInfo | undefined;
   private chainId: string | undefined;
   private rpc: string | undefined;
+  private chainData: BBNConfig["chainData"];
 
   constructor(
     private keplr: Window["keplr"],
@@ -59,8 +60,6 @@ export class KeplrProvider extends BBNProvider {
     const key = await this.keplr.getKey(this.chainId);
 
     if (!key) throw new Error("Failed to get Keplr key");
-
-    this.offlineSigner = this.keplr.getOfflineSigner(this.chainId);
 
     const { bech32Address, pubKey } = key;
 


### PR DESCRIPTION
- Minimize Keplr interface
- Remove the Stargate client Keplr provider dependency. This is still an internal repository `npm` dependency as will be used later on in tests
- Returns the offline signer so the outside world (like `simple-staking`) can use it
- Adds `getWalletProviderName` and `getWalletProviderIcon`

Closes #55 and #63 