### PR TITLE
feat: ECDSA signMessage option

### DIFF
--- a/.changeset/shy-poems-buy.md
+++ b/.changeset/shy-poems-buy.md
@@ -1,0 +1,5 @@
+---
+"@babylonlabs-io/bbn-wallet-connect": patch
+---
+
+ECDSA as the only option in signMessage

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -179,7 +179,7 @@ export interface IBTCProvider extends IProvider {
    * @param type - The signing method to use.
    * @returns A promise that resolves to the signed message.
    */
-  signMessage(message: string, type: "ecdsa" | "bip322-simple"): Promise<string>;
+  signMessage(message: string, type: "ecdsa"): Promise<string>;
 
   /**
    * Retrieves the inscriptions for the connected wallet.


### PR DESCRIPTION
Leaves `ecdsa` as the only option in the provider