### PR TITLE
feat: Keystone - init ecc curve from btc-staking-ts, update deps

### DIFF
--- a/.changeset/lazy-wombats-turn.md
+++ b/.changeset/lazy-wombats-turn.md
@@ -1,0 +1,5 @@
+---
+"@babylonlabs-io/bbn-wallet-connect": patch
+---
+
+keystone: ecc curve from btc-staking, update deps

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
         "@bitcoin-js/tiny-secp256k1-asmjs": "^2.2.3",
         "@cosmjs/stargate": "^0.32.4",
         "@keplr-wallet/types": "^0.12.156",
-        "@keystonehq/animated-qr": "^0.8.6",
-        "@keystonehq/keystone-sdk": "^0.4.1",
+        "@keystonehq/animated-qr": "0.10.0",
+        "@keystonehq/keystone-sdk": "0.9.0",
         "@keystonehq/sdk": "0.22.1",
         "buffer": "^6.0.3",
         "nanoevents": "^9.1.0"
@@ -27,7 +27,6 @@
         "@storybook/react": "^8.4.2",
         "@storybook/react-vite": "^8.4.2",
         "@storybook/test": "^8.4.2",
-        "@types/bitcoinjs-lib": "^5.0.4",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^4.3.3",
@@ -57,6 +56,7 @@
       },
       "peerDependencies": {
         "@babylonlabs-io/bbn-core-ui": "^0.6.1",
+        "@babylonlabs-io/btc-staking-ts": "^0.4.0-canary.5",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "tailwind-merge": "^2.5.4"
@@ -427,6 +427,20 @@
         "react-dom": "^18.3.1",
         "tailwind-merge": "^2.5.4",
         "yup": "^1.5.0"
+      }
+    },
+    "node_modules/@babylonlabs-io/btc-staking-ts": {
+      "version": "0.4.0-canary.3-test",
+      "resolved": "https://registry.npmjs.org/@babylonlabs-io/btc-staking-ts/-/btc-staking-ts-0.4.0-canary.3-test.tgz",
+      "integrity": "sha512-3FOes5cLZeTr961EvwJc2nGwDqXFygM9JDm5YhOQZYZmq1tc2d9F9WR9Xl4r5u/X/ScSt74G+em/UEWfAXq3rw==",
+      "license": "SEE LICENSE IN LICENSE",
+      "peer": true,
+      "dependencies": {
+        "@bitcoin-js/tiny-secp256k1-asmjs": "2.2.3",
+        "bitcoinjs-lib": "6.1.5"
+      },
+      "engines": {
+        "node": "22.3.0"
       }
     },
     "node_modules/@bitcoin-js/tiny-secp256k1-asmjs": {
@@ -1456,29 +1470,28 @@
       }
     },
     "node_modules/@ethereumjs/rlp": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/rlp/-/rlp-4.0.1.tgz",
-      "integrity": "sha512-tqsQiBQDQdmPWE1xkkBq4rlSW5QZpLOUJ5RJh2/9fug+q9tnUhuZoVLk7s0scUIKTOzEtR72DFBXI4WiZcMpvw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/rlp/-/rlp-5.0.2.tgz",
+      "integrity": "sha512-DziebCdg4JpGlEqEdGgXmjqcFoJi+JGulUXwEjsZGAscAQ7MyD/7LE/GVCP29vEQxKc7AAwjT3A2ywHp2xfoCA==",
       "license": "MPL-2.0",
       "bin": {
-        "rlp": "bin/rlp"
+        "rlp": "bin/rlp.cjs"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/@ethereumjs/util": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/util/-/util-8.1.0.tgz",
-      "integrity": "sha512-zQ0IqbdX8FZ9aw11vP+dZkKDkS+kgIvQPHnSAXzP9pLu+Rfu3D3XEeLbicvoXJTYnhZiPmsZUxgdzXwNKxRPbA==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/util/-/util-9.1.0.tgz",
+      "integrity": "sha512-XBEKsYqLGXLah9PNJbgdkigthkG7TAGvlD/sH12beMXEyHDyigfcbdvHhmLyDWgDyOJn4QwiQUaF7yeuhnjdog==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ethereumjs/rlp": "^4.0.1",
-        "ethereum-cryptography": "^2.0.0",
-        "micro-ftch": "^0.3.1"
+        "@ethereumjs/rlp": "^5.0.2",
+        "ethereum-cryptography": "^2.2.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/@hookform/resolvers": {
@@ -1736,12 +1749,12 @@
       "license": "MIT"
     },
     "node_modules/@keystonehq/animated-qr": {
-      "version": "0.8.6",
-      "resolved": "https://registry.npmjs.org/@keystonehq/animated-qr/-/animated-qr-0.8.6.tgz",
-      "integrity": "sha512-qDJ79ckxi8J27hRncS5KaCe9OQJ8ZUMSOjQrPt8V5ZOEEeeAzsmKFa8eytW9Cq2j7VQhWrdEYlDmWqcfYc/2lg==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@keystonehq/animated-qr/-/animated-qr-0.10.0.tgz",
+      "integrity": "sha512-zSblr0m790w4niDckc93x5AnYtsvdbuiDKf7hhc+sODmEKY/7/7r5E9HszWzuxtQPq215bfVFY37AtO3IXSTpQ==",
       "license": "MIT",
       "dependencies": {
-        "@keystonehq/ur-decoder": "^0.12.2",
+        "@keystonehq/animated-qr-base": "^0.0.1",
         "@ngraveio/bc-ur": "^1.1.6",
         "@zxing/browser": "^0.1.1",
         "@zxing/library": "^0.19.1",
@@ -1750,6 +1763,15 @@
       "peerDependencies": {
         "react": ">= 16.8",
         "react-dom": ">= 16.8"
+      }
+    },
+    "node_modules/@keystonehq/animated-qr-base": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@keystonehq/animated-qr-base/-/animated-qr-base-0.0.1.tgz",
+      "integrity": "sha512-yc+W05y/l6ZWref6aaadg2en9wXAuXUbR5659cbv8qoVFbcMp3L+BpMNBxfWNUMdx2xSQQhMpsfcPP9K1ykJ+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "@ngraveio/bc-ur": "^1.1.13"
       }
     },
     "node_modules/@keystonehq/animated-qr/node_modules/@zxing/library": {
@@ -1768,9 +1790,9 @@
       }
     },
     "node_modules/@keystonehq/bc-ur-registry": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry/-/bc-ur-registry-0.6.4.tgz",
-      "integrity": "sha512-j8Uy44DuAkvYkbf0jMxRY3UizJfn8wsEQr7GS3miRF44vcq7k0/yemVkftbn3jQ+0JYaUXf5wY7lVpLhAeW5nQ==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry/-/bc-ur-registry-0.7.0.tgz",
+      "integrity": "sha512-E6NUd6Y+YYM+IcYGOEXfO9+MU1s63Qjm8brtHftvNhxbdXhGtTYIsa4FQmqZ6q34q91bMkMqUQFsQYPmIxcxfg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ngraveio/bc-ur": "^1.1.5",
@@ -1779,20 +1801,20 @@
       }
     },
     "node_modules/@keystonehq/bc-ur-registry-aptos": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry-aptos/-/bc-ur-registry-aptos-0.3.2.tgz",
-      "integrity": "sha512-ZQ+gsif+R5rF9fXpG9+atoj/o00iceo91uFw/zpXMZLmJgMIs9EcfM7SXrPmLm/KvMfigsYXPj1epTCg3GOSSg==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry-aptos/-/bc-ur-registry-aptos-0.6.3.tgz",
+      "integrity": "sha512-NJipiLJpu/pxocCUz8yiQUwmjHtu5XEDhhZHoNFE4M5B9WoZTae+wDCt6dTZD42XlePkPIgLAotBKIKmSHMGRQ==",
       "license": "ISC",
       "dependencies": {
-        "@keystonehq/bc-ur-registry": "0.5.4",
+        "@keystonehq/bc-ur-registry": "^0.6.4",
         "bs58check": "^2.1.2",
         "uuid": "^8.3.2"
       }
     },
     "node_modules/@keystonehq/bc-ur-registry-aptos/node_modules/@keystonehq/bc-ur-registry": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry/-/bc-ur-registry-0.5.4.tgz",
-      "integrity": "sha512-z7bZe10I5k0zz9znmDTXh+o3Rzb5XsRVpwAzexubOaLxVdZ0F7aMbe2LoEsw766Hpox/7zARi7UGmLz5C8BAzA==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry/-/bc-ur-registry-0.6.4.tgz",
+      "integrity": "sha512-j8Uy44DuAkvYkbf0jMxRY3UizJfn8wsEQr7GS3miRF44vcq7k0/yemVkftbn3jQ+0JYaUXf5wY7lVpLhAeW5nQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ngraveio/bc-ur": "^1.1.5",
@@ -1839,19 +1861,19 @@
       }
     },
     "node_modules/@keystonehq/bc-ur-registry-arweave": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry-arweave/-/bc-ur-registry-arweave-0.4.0.tgz",
-      "integrity": "sha512-PDCYpOOHp1elRQeWutol4n5NE7Briv2K1ho70FrTbU7N7W8CEbUlRlEeb78cq/P0LtIuw6NR6byRrQQ36ZmPhw==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry-arweave/-/bc-ur-registry-arweave-0.5.3.tgz",
+      "integrity": "sha512-b5OAzhW7HLaOX7OEyWA+Bz+4EJIzCT7c+JXU0TElzpBD5rGo4ylf+StuyV6WnuKx5NV11fv9k2XDyHit26CCLA==",
       "license": "ISC",
       "dependencies": {
-        "@keystonehq/bc-ur-registry": "0.5.4",
+        "@keystonehq/bc-ur-registry": "^0.6.4",
         "uuid": "^8.3.2"
       }
     },
     "node_modules/@keystonehq/bc-ur-registry-arweave/node_modules/@keystonehq/bc-ur-registry": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry/-/bc-ur-registry-0.5.4.tgz",
-      "integrity": "sha512-z7bZe10I5k0zz9znmDTXh+o3Rzb5XsRVpwAzexubOaLxVdZ0F7aMbe2LoEsw766Hpox/7zARi7UGmLz5C8BAzA==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry/-/bc-ur-registry-0.6.4.tgz",
+      "integrity": "sha512-j8Uy44DuAkvYkbf0jMxRY3UizJfn8wsEQr7GS3miRF44vcq7k0/yemVkftbn3jQ+0JYaUXf5wY7lVpLhAeW5nQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ngraveio/bc-ur": "^1.1.5",
@@ -1907,6 +1929,46 @@
         "uuid": "^8.3.2"
       }
     },
+    "node_modules/@keystonehq/bc-ur-registry-btc/node_modules/@keystonehq/bc-ur-registry": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry/-/bc-ur-registry-0.6.4.tgz",
+      "integrity": "sha512-j8Uy44DuAkvYkbf0jMxRY3UizJfn8wsEQr7GS3miRF44vcq7k0/yemVkftbn3jQ+0JYaUXf5wY7lVpLhAeW5nQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ngraveio/bc-ur": "^1.1.5",
+        "bs58check": "^2.1.2",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@keystonehq/bc-ur-registry-btc/node_modules/base-x": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.10.tgz",
+      "integrity": "sha512-7d0s06rR9rYaIWHkpfLIFICM/tkSVdoPC9qYAQRpxn9DdKNWNsKC0uk++akckyLq16Tx2WIinnZ6WRriAt6njQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@keystonehq/bc-ur-registry-btc/node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^3.0.2"
+      }
+    },
+    "node_modules/@keystonehq/bc-ur-registry-btc/node_modules/bs58check": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+      "license": "MIT",
+      "dependencies": {
+        "bs58": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "safe-buffer": "^5.1.2"
+      }
+    },
     "node_modules/@keystonehq/bc-ur-registry-btc/node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -1917,13 +1979,53 @@
       }
     },
     "node_modules/@keystonehq/bc-ur-registry-cardano": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry-cardano/-/bc-ur-registry-cardano-0.3.9.tgz",
-      "integrity": "sha512-moQtGVjRpzJmHBGxITjljKVE8b2wIC72/9UtuqIfeWWUz/gHWZ4zB0jrz+YgnNwhIizEKmydjtOHLSFrbUQ9VQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry-cardano/-/bc-ur-registry-cardano-0.4.0.tgz",
+      "integrity": "sha512-xkFkD+FIG72rZiMgCtuNvXm63ik53C1yL3w8nnAG+1q3x6vomo3hv/Ve5ZE0uL7kEXw6wQ8s8gW1MczR1xZxgg==",
       "license": "ISC",
       "dependencies": {
         "@keystonehq/bc-ur-registry": "^0.6.4",
         "uuid": "^8.3.2"
+      }
+    },
+    "node_modules/@keystonehq/bc-ur-registry-cardano/node_modules/@keystonehq/bc-ur-registry": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry/-/bc-ur-registry-0.6.4.tgz",
+      "integrity": "sha512-j8Uy44DuAkvYkbf0jMxRY3UizJfn8wsEQr7GS3miRF44vcq7k0/yemVkftbn3jQ+0JYaUXf5wY7lVpLhAeW5nQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ngraveio/bc-ur": "^1.1.5",
+        "bs58check": "^2.1.2",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@keystonehq/bc-ur-registry-cardano/node_modules/base-x": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.10.tgz",
+      "integrity": "sha512-7d0s06rR9rYaIWHkpfLIFICM/tkSVdoPC9qYAQRpxn9DdKNWNsKC0uk++akckyLq16Tx2WIinnZ6WRriAt6njQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@keystonehq/bc-ur-registry-cardano/node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^3.0.2"
+      }
+    },
+    "node_modules/@keystonehq/bc-ur-registry-cardano/node_modules/bs58check": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+      "license": "MIT",
+      "dependencies": {
+        "bs58": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "safe-buffer": "^5.1.2"
       }
     },
     "node_modules/@keystonehq/bc-ur-registry-cardano/node_modules/uuid": {
@@ -1936,20 +2038,20 @@
       }
     },
     "node_modules/@keystonehq/bc-ur-registry-cosmos": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry-cosmos/-/bc-ur-registry-cosmos-0.2.2.tgz",
-      "integrity": "sha512-bZfjyDiAHv6d9Xt++3fbTDvvdSBJPAGphotStMy2wFbQFxdWww7IPZyPIFJwCeIcFTfapYpF/UsZ1xly40068Q==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry-cosmos/-/bc-ur-registry-cosmos-0.5.3.tgz",
+      "integrity": "sha512-bCmm2LMM4EHiLrjhfkbzfnwTXi4ez56MfwKYke8Z0roeaJbHmr2KkCg6/MePLjeK9PRbY0jKXBmCowMe2DhfhA==",
       "license": "ISC",
       "dependencies": {
-        "@keystonehq/bc-ur-registry": "0.5.4",
+        "@keystonehq/bc-ur-registry": "^0.6.4",
         "bs58check": "^2.1.2",
         "uuid": "^8.3.2"
       }
     },
     "node_modules/@keystonehq/bc-ur-registry-cosmos/node_modules/@keystonehq/bc-ur-registry": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry/-/bc-ur-registry-0.5.4.tgz",
-      "integrity": "sha512-z7bZe10I5k0zz9znmDTXh+o3Rzb5XsRVpwAzexubOaLxVdZ0F7aMbe2LoEsw766Hpox/7zARi7UGmLz5C8BAzA==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry/-/bc-ur-registry-0.6.4.tgz",
+      "integrity": "sha512-j8Uy44DuAkvYkbf0jMxRY3UizJfn8wsEQr7GS3miRF44vcq7k0/yemVkftbn3jQ+0JYaUXf5wY7lVpLhAeW5nQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ngraveio/bc-ur": "^1.1.5",
@@ -1996,21 +2098,21 @@
       }
     },
     "node_modules/@keystonehq/bc-ur-registry-eth": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry-eth/-/bc-ur-registry-eth-0.15.2.tgz",
-      "integrity": "sha512-M096p7RD4SfcU+EQOISa0eTGyr5+Ls4hKOx3pDVWu8Y3TlWZFgFE39ma+zLqKTzGjkt6Ita96dT2u2p4pZfyTA==",
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry-eth/-/bc-ur-registry-eth-0.20.1.tgz",
+      "integrity": "sha512-vQpqhj2DeDI1/xwY3eqj1PWgqqTdg53RgMVBUZUV3O8CSc0nbnH4SaP3cx85KEOO+4Loq6SXHbFJr1egalM2ng==",
       "license": "ISC",
       "dependencies": {
-        "@ethereumjs/util": "^8.0.0",
-        "@keystonehq/bc-ur-registry": "0.5.4",
+        "@ethereumjs/util": "^9.0.3",
+        "@keystonehq/bc-ur-registry": "^0.6.4",
         "hdkey": "^2.0.1",
         "uuid": "^8.3.2"
       }
     },
     "node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry/-/bc-ur-registry-0.5.4.tgz",
-      "integrity": "sha512-z7bZe10I5k0zz9znmDTXh+o3Rzb5XsRVpwAzexubOaLxVdZ0F7aMbe2LoEsw766Hpox/7zARi7UGmLz5C8BAzA==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry/-/bc-ur-registry-0.6.4.tgz",
+      "integrity": "sha512-j8Uy44DuAkvYkbf0jMxRY3UizJfn8wsEQr7GS3miRF44vcq7k0/yemVkftbn3jQ+0JYaUXf5wY7lVpLhAeW5nQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ngraveio/bc-ur": "^1.1.5",
@@ -2067,6 +2169,17 @@
         "uuid": "^9.0.0"
       }
     },
+    "node_modules/@keystonehq/bc-ur-registry-evm/node_modules/@keystonehq/bc-ur-registry": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry/-/bc-ur-registry-0.6.4.tgz",
+      "integrity": "sha512-j8Uy44DuAkvYkbf0jMxRY3UizJfn8wsEQr7GS3miRF44vcq7k0/yemVkftbn3jQ+0JYaUXf5wY7lVpLhAeW5nQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ngraveio/bc-ur": "^1.1.5",
+        "bs58check": "^2.1.2",
+        "tslib": "^2.3.0"
+      }
+    },
     "node_modules/@keystonehq/bc-ur-registry-evm/node_modules/base-x": {
       "version": "3.0.10",
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.10.tgz",
@@ -2097,18 +2210,18 @@
       }
     },
     "node_modules/@keystonehq/bc-ur-registry-keystone": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry-keystone/-/bc-ur-registry-keystone-0.1.0.tgz",
-      "integrity": "sha512-ev9Vi5h+ewFmKCBVFoOgWmF17RuG31UQKmTXjByD0p2QxCrIOpa5XWGKEpxrfl7Y2ulLpAloVt3Oy9FY5g38bQ==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry-keystone/-/bc-ur-registry-keystone-0.4.3.tgz",
+      "integrity": "sha512-YTf0p9TYYq9+bfF/wMEE2gbhNiV1S0m31hMwnl+4kn3q1avwlrXZ6h30nANZXD31NQ8hMuLO8x7Ny+0AldmAOA==",
       "license": "ISC",
       "dependencies": {
-        "@keystonehq/bc-ur-registry": "0.5.4"
+        "@keystonehq/bc-ur-registry": "^0.6.4"
       }
     },
     "node_modules/@keystonehq/bc-ur-registry-keystone/node_modules/@keystonehq/bc-ur-registry": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry/-/bc-ur-registry-0.5.4.tgz",
-      "integrity": "sha512-z7bZe10I5k0zz9znmDTXh+o3Rzb5XsRVpwAzexubOaLxVdZ0F7aMbe2LoEsw766Hpox/7zARi7UGmLz5C8BAzA==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry/-/bc-ur-registry-0.6.4.tgz",
+      "integrity": "sha512-j8Uy44DuAkvYkbf0jMxRY3UizJfn8wsEQr7GS3miRF44vcq7k0/yemVkftbn3jQ+0JYaUXf5wY7lVpLhAeW5nQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ngraveio/bc-ur": "^1.1.5",
@@ -2146,20 +2259,20 @@
       }
     },
     "node_modules/@keystonehq/bc-ur-registry-near": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry-near/-/bc-ur-registry-near-0.8.0.tgz",
-      "integrity": "sha512-xyNTiTeSBqEpjvLlNR3DZKbP6P7+JALa8rgsO7+b9C2kUEdDmTQ6jEquD4V+zMS86AeT+GhGxnAvZWF+jaZMZA==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry-near/-/bc-ur-registry-near-0.9.3.tgz",
+      "integrity": "sha512-+JHxlxwa4pbZXODSZYcIHN42XZZYblNQFp6ogP0yyqct1ayVbAgz/RoYdLrfdNJ4TDvPRClOPDIvZSiUFYCpaw==",
       "license": "ISC",
       "dependencies": {
-        "@keystonehq/bc-ur-registry": "0.5.4",
+        "@keystonehq/bc-ur-registry": "^0.6.4",
         "bs58check": "^2.1.2",
         "uuid": "^8.3.2"
       }
     },
     "node_modules/@keystonehq/bc-ur-registry-near/node_modules/@keystonehq/bc-ur-registry": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry/-/bc-ur-registry-0.5.4.tgz",
-      "integrity": "sha512-z7bZe10I5k0zz9znmDTXh+o3Rzb5XsRVpwAzexubOaLxVdZ0F7aMbe2LoEsw766Hpox/7zARi7UGmLz5C8BAzA==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry/-/bc-ur-registry-0.6.4.tgz",
+      "integrity": "sha512-j8Uy44DuAkvYkbf0jMxRY3UizJfn8wsEQr7GS3miRF44vcq7k0/yemVkftbn3jQ+0JYaUXf5wY7lVpLhAeW5nQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ngraveio/bc-ur": "^1.1.5",
@@ -2206,25 +2319,14 @@
       }
     },
     "node_modules/@keystonehq/bc-ur-registry-sol": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry-sol/-/bc-ur-registry-sol-0.6.2.tgz",
-      "integrity": "sha512-iI+OvugXchZ1D1FXuagqd5MvPhgV/9QdojA+aTKzE9GYwdAkhRqaqC+ORH58mw32dZAtRttXwH0tJsBAZfQRKw==",
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry-sol/-/bc-ur-registry-sol-0.9.5.tgz",
+      "integrity": "sha512-HZeeph9297ZHjAziE9wL/u2W1dmV0p1H9Bu9g1bLJazP4F6W2fjCK9BAoCiKEsMBqadk6KI6r6VD67fmDzWyug==",
       "license": "ISC",
       "dependencies": {
-        "@keystonehq/bc-ur-registry": "0.5.4",
+        "@keystonehq/bc-ur-registry": "^0.7.0",
         "bs58check": "^2.1.2",
         "uuid": "^8.3.2"
-      }
-    },
-    "node_modules/@keystonehq/bc-ur-registry-sol/node_modules/@keystonehq/bc-ur-registry": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry/-/bc-ur-registry-0.5.4.tgz",
-      "integrity": "sha512-z7bZe10I5k0zz9znmDTXh+o3Rzb5XsRVpwAzexubOaLxVdZ0F7aMbe2LoEsw766Hpox/7zARi7UGmLz5C8BAzA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ngraveio/bc-ur": "^1.1.5",
-        "bs58check": "^2.1.2",
-        "tslib": "^2.3.0"
       }
     },
     "node_modules/@keystonehq/bc-ur-registry-sol/node_modules/base-x": {
@@ -2265,14 +2367,114 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/@keystonehq/bc-ur-registry-stellar": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry-stellar/-/bc-ur-registry-stellar-0.0.4.tgz",
+      "integrity": "sha512-L/naB3+/386htOrePisgQsTUOIKgIWpXS6FF24TTkyWWr/SHQV3PNOYXOnMto+WKABv6+BbG6AAnsw/7UuONLg==",
+      "license": "ISC",
+      "dependencies": {
+        "@keystonehq/bc-ur-registry": "^0.6.4",
+        "bs58check": "^2.1.2",
+        "uuid": "^8.3.2"
+      }
+    },
+    "node_modules/@keystonehq/bc-ur-registry-stellar/node_modules/@keystonehq/bc-ur-registry": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry/-/bc-ur-registry-0.6.4.tgz",
+      "integrity": "sha512-j8Uy44DuAkvYkbf0jMxRY3UizJfn8wsEQr7GS3miRF44vcq7k0/yemVkftbn3jQ+0JYaUXf5wY7lVpLhAeW5nQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ngraveio/bc-ur": "^1.1.5",
+        "bs58check": "^2.1.2",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@keystonehq/bc-ur-registry-stellar/node_modules/base-x": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.10.tgz",
+      "integrity": "sha512-7d0s06rR9rYaIWHkpfLIFICM/tkSVdoPC9qYAQRpxn9DdKNWNsKC0uk++akckyLq16Tx2WIinnZ6WRriAt6njQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@keystonehq/bc-ur-registry-stellar/node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^3.0.2"
+      }
+    },
+    "node_modules/@keystonehq/bc-ur-registry-stellar/node_modules/bs58check": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+      "license": "MIT",
+      "dependencies": {
+        "bs58": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/@keystonehq/bc-ur-registry-stellar/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@keystonehq/bc-ur-registry-sui": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry-sui/-/bc-ur-registry-sui-0.3.1.tgz",
-      "integrity": "sha512-cbxu5AF5xFg9J3p0AXIkp1IMGSSNsaXWRgn22bcnkIlzwMEwmgJR5J/Lg45MIyIpW2p17fKyYqc9yuP0iMALEQ==",
+      "version": "0.4.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry-sui/-/bc-ur-registry-sui-0.4.0-alpha.0.tgz",
+      "integrity": "sha512-pwT+wyRnmnXdwMe2buMq3lQzDWc6kj2rxR8THI7fx3dUjYRzb6H4+/A+qwBlq24RWWtHfptLTPMk+LWVy9ABDA==",
       "license": "ISC",
       "dependencies": {
         "@keystonehq/bc-ur-registry": "^0.6.4",
         "uuid": "^9.0.0"
+      }
+    },
+    "node_modules/@keystonehq/bc-ur-registry-sui/node_modules/@keystonehq/bc-ur-registry": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry/-/bc-ur-registry-0.6.4.tgz",
+      "integrity": "sha512-j8Uy44DuAkvYkbf0jMxRY3UizJfn8wsEQr7GS3miRF44vcq7k0/yemVkftbn3jQ+0JYaUXf5wY7lVpLhAeW5nQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ngraveio/bc-ur": "^1.1.5",
+        "bs58check": "^2.1.2",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@keystonehq/bc-ur-registry-sui/node_modules/base-x": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.10.tgz",
+      "integrity": "sha512-7d0s06rR9rYaIWHkpfLIFICM/tkSVdoPC9qYAQRpxn9DdKNWNsKC0uk++akckyLq16Tx2WIinnZ6WRriAt6njQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@keystonehq/bc-ur-registry-sui/node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^3.0.2"
+      }
+    },
+    "node_modules/@keystonehq/bc-ur-registry-sui/node_modules/bs58check": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+      "license": "MIT",
+      "dependencies": {
+        "bs58": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "safe-buffer": "^5.1.2"
       }
     },
     "node_modules/@keystonehq/bc-ur-registry-ton": {
@@ -2283,6 +2485,46 @@
       "dependencies": {
         "@keystonehq/bc-ur-registry": "^0.6.4",
         "uuid": "^9.0.0"
+      }
+    },
+    "node_modules/@keystonehq/bc-ur-registry-ton/node_modules/@keystonehq/bc-ur-registry": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry/-/bc-ur-registry-0.6.4.tgz",
+      "integrity": "sha512-j8Uy44DuAkvYkbf0jMxRY3UizJfn8wsEQr7GS3miRF44vcq7k0/yemVkftbn3jQ+0JYaUXf5wY7lVpLhAeW5nQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ngraveio/bc-ur": "^1.1.5",
+        "bs58check": "^2.1.2",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@keystonehq/bc-ur-registry-ton/node_modules/base-x": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.10.tgz",
+      "integrity": "sha512-7d0s06rR9rYaIWHkpfLIFICM/tkSVdoPC9qYAQRpxn9DdKNWNsKC0uk++akckyLq16Tx2WIinnZ6WRriAt6njQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@keystonehq/bc-ur-registry-ton/node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^3.0.2"
+      }
+    },
+    "node_modules/@keystonehq/bc-ur-registry-ton/node_modules/bs58check": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+      "license": "MIT",
+      "dependencies": {
+        "bs58": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "safe-buffer": "^5.1.2"
       }
     },
     "node_modules/@keystonehq/bc-ur-registry/node_modules/base-x": {
@@ -2315,26 +2557,28 @@
       }
     },
     "node_modules/@keystonehq/keystone-sdk": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@keystonehq/keystone-sdk/-/keystone-sdk-0.4.1.tgz",
-      "integrity": "sha512-f0vat1DYs3CpbN2KjtMF2ZGW5kSWTYQtLghCM8eErANTDk3Nk9R//NdKXUZC1LVRB3GUv6jJOy1Rbq+6sPsJ5Q==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@keystonehq/keystone-sdk/-/keystone-sdk-0.9.0.tgz",
+      "integrity": "sha512-sP2DFvQucmyz3mP+b11EYcc0sXuANHoH8esZpsGaf67+Rv4RcbJfx0Au7JZKrxwcKWLbKrI9a2h3J6Tt7SvoRQ==",
       "license": "ISC",
       "dependencies": {
         "@bufbuild/protobuf": "^1.2.0",
-        "@keystonehq/bc-ur-registry": "^0.6.4",
-        "@keystonehq/bc-ur-registry-aptos": "^0.3.2",
-        "@keystonehq/bc-ur-registry-arweave": "^0.4.0",
-        "@keystonehq/bc-ur-registry-btc": "^0.1.0",
-        "@keystonehq/bc-ur-registry-cardano": "^0.3.0",
-        "@keystonehq/bc-ur-registry-cosmos": "^0.2.2",
-        "@keystonehq/bc-ur-registry-eth": "^0.15.2",
-        "@keystonehq/bc-ur-registry-evm": "^0.5.2",
-        "@keystonehq/bc-ur-registry-keystone": "^0.1.0",
-        "@keystonehq/bc-ur-registry-near": "^0.8.0",
-        "@keystonehq/bc-ur-registry-sol": "^0.6.2",
-        "@keystonehq/bc-ur-registry-sui": "^0.3.0",
-        "@keystonehq/bc-ur-registry-ton": "^0.1.0",
+        "@keystonehq/bc-ur-registry": "^0.7.0",
+        "@keystonehq/bc-ur-registry-aptos": "^0.6.3",
+        "@keystonehq/bc-ur-registry-arweave": "^0.5.3",
+        "@keystonehq/bc-ur-registry-btc": "^0.1.1",
+        "@keystonehq/bc-ur-registry-cardano": "^0.4.0",
+        "@keystonehq/bc-ur-registry-cosmos": "^0.5.3",
+        "@keystonehq/bc-ur-registry-eth": "^0.20.1",
+        "@keystonehq/bc-ur-registry-evm": "^0.5.3",
+        "@keystonehq/bc-ur-registry-keystone": "^0.4.3",
+        "@keystonehq/bc-ur-registry-near": "^0.9.3",
+        "@keystonehq/bc-ur-registry-sol": "^0.9.3",
+        "@keystonehq/bc-ur-registry-stellar": "^0.0.4",
+        "@keystonehq/bc-ur-registry-sui": "0.4.0-alpha.0",
+        "@keystonehq/bc-ur-registry-ton": "^0.1.2",
         "@ngraveio/bc-ur": "^1.1.6",
+        "@noble/hashes": "^1.5.0",
         "bs58check": "^3.0.1",
         "pako": "^2.1.0",
         "ripple-binary-codec": "^1.4.3",
@@ -2356,48 +2600,6 @@
       "peerDependencies": {
         "react": "^16 || ^17 || ^18",
         "react-dom": "^16 || ^17 || ^18"
-      }
-    },
-    "node_modules/@keystonehq/ur-decoder": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/@keystonehq/ur-decoder/-/ur-decoder-0.12.2.tgz",
-      "integrity": "sha512-qFmNFR2fsk3YAs3bF6nFO2Ny79Cl0gaZC5S7fjzQPyClUxFL2OwuEYLBcFT+Q7n6mbInuH4rCBHU4UWXf3FKGg==",
-      "license": "ISC",
-      "dependencies": {
-        "@keystonehq/bc-ur-registry-eth": "^0.6.12",
-        "@ngraveio/bc-ur": "^1.1.6"
-      }
-    },
-    "node_modules/@keystonehq/ur-decoder/node_modules/@keystonehq/bc-ur-registry": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry/-/bc-ur-registry-0.4.4.tgz",
-      "integrity": "sha512-SBdKdAZfp3y14GTGrKjfJJHf4iXObjcm4/qKUZ92lj8HVR8mxHHGmHksjE328bJPTAsJPloLix4rTnWg+qgS2w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ngraveio/bc-ur": "^1.1.5",
-        "base58check": "^2.0.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "node_modules/@keystonehq/ur-decoder/node_modules/@keystonehq/bc-ur-registry-eth": {
-      "version": "0.6.14",
-      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry-eth/-/bc-ur-registry-eth-0.6.14.tgz",
-      "integrity": "sha512-Zr0VAUJuzz5zfH2263AucdWPUYuclpd93Pmi/VzbML72sQLv8l83kQWmQpI+7639uV5dHcOj6JnD8FhCPYPRFQ==",
-      "license": "ISC",
-      "dependencies": {
-        "@keystonehq/bc-ur-registry": "^0.4.4",
-        "ethereumjs-util": "^7.0.8",
-        "hdkey": "^2.0.1",
-        "uuid": "^8.3.2"
-      }
-    },
-    "node_modules/@keystonehq/ur-decoder/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@manypkg/find-root": {
@@ -4174,26 +4376,6 @@
         "@babel/types": "^7.20.7"
       }
     },
-    "node_modules/@types/bitcoinjs-lib": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@types/bitcoinjs-lib/-/bitcoinjs-lib-5.0.4.tgz",
-      "integrity": "sha512-4IXPR8tIDNZPsWk6TQxOpbZnpZsoRCuwuUzlqw8aO1hQEDi1J5x46+HlI4Xh7ECmdoIwnAB8bGvTdnVuBSDZXQ==",
-      "deprecated": "This is a stub types definition. bitcoinjs-lib provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bitcoinjs-lib": "*"
-      }
-    },
-    "node_modules/@types/bn.js": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.6.tgz",
-      "integrity": "sha512-Xh8vSwUeMKeYYrj3cX4lGQgFSF/N03r+tv4AiLl1SucqV+uTQpxRcnM8AkXKHwYP9ZPXOYXRr2KPXpVlIvqh9w==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/doctrine": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/@types/doctrine/-/doctrine-0.0.9.tgz",
@@ -4244,15 +4426,6 @@
         "undici-types": "~6.20.0"
       }
     },
-    "node_modules/@types/pbkdf2": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.2.tgz",
-      "integrity": "sha512-uRwJqmiXmh9++aSu1VNEn3iIxWOhd8AHXNSdlaLfdAAdSTY9jYVeGWnzejM3dvrkbqE3/hyQkQQ29IFATEGlew==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/prop-types": {
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
@@ -4287,15 +4460,6 @@
       "integrity": "sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/secp256k1": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.6.tgz",
-      "integrity": "sha512-hHxJU6PAEUn0TP4S/ZOzuTUvJWuZ6eIKeNKb5RBpODvSl6hp1Wrw4s7ATY50rklRCScUDpHzVA/DQdSjJ3UoYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/uuid": {
       "version": "9.0.8",
@@ -5327,30 +5491,6 @@
       "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw==",
       "license": "MIT"
     },
-    "node_modules/base58check": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/base58check/-/base58check-2.0.0.tgz",
-      "integrity": "sha512-sTzsDAOC9+i2Ukr3p1Ie2DWpD117ua+vBJRDnpsSlScGwImeeiTg/IatwcFLsz9K9wEGoBLVd5ahNZzrZ/jZyg==",
-      "license": "MIT",
-      "dependencies": {
-        "bs58": "^3.0.0"
-      }
-    },
-    "node_modules/base58check/node_modules/base-x": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-1.1.0.tgz",
-      "integrity": "sha512-c0WLeG3K5OlL4Skz2/LVdS+MjggByKhowxQpG+JpCLA48s/bGwIDyzA1naFjywtNvp/37fLK0p0FpjTNNLLUXQ==",
-      "license": "MIT"
-    },
-    "node_modules/base58check/node_modules/bs58": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-3.1.0.tgz",
-      "integrity": "sha512-9C2bRFTGy3meqO65O9jLvVTyawvhLVp4h2ECm5KlRPuV5KPDNJZcJIj3gl+aA0ENXcYrUSLCkPAeqbTcI2uWyQ==",
-      "license": "MIT",
-      "dependencies": {
-        "base-x": "^1.1.0"
-      }
-    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -5438,18 +5578,18 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bip174/-/bip174-2.1.1.tgz",
       "integrity": "sha512-mdFV5+/v0XyNYXjBS6CQPLo9ekCx4gtKZFnJm5PMto7Fs9hTTDpkkzOB7/FtluRI6JbUUAu+snTYfJRgHLZbZQ==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/bitcoinjs-lib": {
-      "version": "6.1.7",
-      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-6.1.7.tgz",
-      "integrity": "sha512-tlf/r2DGMbF7ky1MgUqXHzypYHakkEnm0SZP23CJKIqNY/5uNAnMbFhMJdhjrL/7anfb/U8+AlpdjPWjPnAalg==",
-      "dev": true,
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-6.1.5.tgz",
+      "integrity": "sha512-yuf6xs9QX/E8LWE2aMJPNd0IxGofwfuVOiYdNUESkc+2bHHVKjhJd8qewqapeoolh9fihzHGoDCB5Vkr57RZCQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@noble/hashes": "^1.2.0",
         "bech32": "^2.0.0",
@@ -5466,14 +5606,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
       "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/blakejs": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
-      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/bn.js": {
       "version": "5.2.1",
@@ -5531,6 +5665,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-xor": "^1.0.3",
@@ -5761,6 +5896,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/builtin-status-codes": {
@@ -6300,6 +6436,7 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cipher-base": "^1.0.3",
@@ -7449,74 +7586,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/ethereumjs-util": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz",
-      "integrity": "sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==",
-      "license": "MPL-2.0",
-      "dependencies": {
-        "@types/bn.js": "^5.1.0",
-        "bn.js": "^5.1.2",
-        "create-hash": "^1.1.2",
-        "ethereum-cryptography": "^0.1.3",
-        "rlp": "^2.2.4"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/ethereumjs-util/node_modules/base-x": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.10.tgz",
-      "integrity": "sha512-7d0s06rR9rYaIWHkpfLIFICM/tkSVdoPC9qYAQRpxn9DdKNWNsKC0uk++akckyLq16Tx2WIinnZ6WRriAt6njQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/ethereumjs-util/node_modules/bs58": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
-      "license": "MIT",
-      "dependencies": {
-        "base-x": "^3.0.2"
-      }
-    },
-    "node_modules/ethereumjs-util/node_modules/bs58check": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
-      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
-      "license": "MIT",
-      "dependencies": {
-        "bs58": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "safe-buffer": "^5.1.2"
-      }
-    },
-    "node_modules/ethereumjs-util/node_modules/ethereum-cryptography": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/pbkdf2": "^3.0.0",
-        "@types/secp256k1": "^4.0.1",
-        "blakejs": "^1.1.0",
-        "browserify-aes": "^1.2.0",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "hash.js": "^1.1.7",
-        "keccak": "^3.0.0",
-        "pbkdf2": "^3.0.17",
-        "randombytes": "^2.1.0",
-        "safe-buffer": "^5.1.2",
-        "scrypt-js": "^3.0.0",
-        "secp256k1": "^4.0.1",
-        "setimmediate": "^1.0.5"
-      }
-    },
     "node_modules/eventemitter3": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
@@ -7538,6 +7607,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "md5.js": "^1.3.4",
@@ -9154,27 +9224,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/keccak": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.4.tgz",
-      "integrity": "sha512-3vKuW0jV8J3XNTzvfyicFR5qvxrSAGl7KIhvgOu5cmWwM7tZRj3fMbj/pfIf4be7aznbc+prBWGjywox/g2Y6Q==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-addon-api": "^2.0.0",
-        "node-gyp-build": "^4.2.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/keccak/node_modules/node-addon-api": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
-      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
-      "license": "MIT"
-    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -9532,12 +9581,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/micro-ftch": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/micro-ftch/-/micro-ftch-0.3.1.tgz",
-      "integrity": "sha512-/0LLxhzP0tfiR5hcQebtudP56gUurs2CLkGarnCiB/OqEyUFQ6U3paQi/tgLv0hBJYt2rnr9MNpxz4fiiugstg==",
-      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -10360,6 +10403,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
       "integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "create-hash": "^1.1.2",
@@ -11020,6 +11064,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.1.0"
@@ -11541,18 +11586,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/rlp": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.7.tgz",
-      "integrity": "sha512-d5gdPmgQ0Z+AklL2NVXr/IoSjNZFfTVvQWzL/AM2AOcSzYP2xjlb0AC8YyCLc41MSNf6P6QVtjgPdmVtzb+4lQ==",
-      "license": "MPL-2.0",
-      "dependencies": {
-        "bn.js": "^5.2.0"
-      },
-      "bin": {
-        "rlp": "bin/rlp"
-      }
-    },
     "node_modules/rollup": {
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.28.1.tgz",
@@ -11708,12 +11741,6 @@
         "loose-envify": "^1.1.0"
       }
     },
-    "node_modules/scrypt-js": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
-      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
-      "license": "MIT"
-    },
     "node_modules/secp256k1": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.4.tgz",
@@ -11786,6 +11813,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/sha.js": {
@@ -12780,8 +12808,8 @@
       "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
       "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/typescript": {
       "version": "5.6.3",
@@ -13001,8 +13029,8 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.2.tgz",
       "integrity": "sha512-4EVb+w4rx+YfVM32HQX42AbbT7/1f5zwAYhIujKXKk8NQK+JfRVl3pqT3hjNn/L+RstigmGGKVwHA/P0wgITZw==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "^5.1.1"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
       },
       "peerDependencies": {
         "@babylonlabs-io/bbn-core-ui": "^0.6.1",
-        "@babylonlabs-io/btc-staking-ts": "^0.4.0-canary.5",
+        "@babylonlabs-io/btc-staking-ts": "0.4.0-canary.5",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "tailwind-merge": "^2.5.4"
@@ -412,9 +412,9 @@
       }
     },
     "node_modules/@babylonlabs-io/bbn-core-ui": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@babylonlabs-io/bbn-core-ui/-/bbn-core-ui-0.6.3.tgz",
-      "integrity": "sha512-Ic+Q/LKGErb15Py28cQsBYCaliiSdCVHsFojqr5Agr16rCGlgsRlsm5XjgtwhZd7+TXwEZzYU90zv9wQ/HNE0A==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@babylonlabs-io/bbn-core-ui/-/bbn-core-ui-0.6.4.tgz",
+      "integrity": "sha512-TeT4y+Cs+DV3FrfwMK8pbprY3AjGRIMaq7pFEShFaDzJnJgIK2MSjHgDlY6SpHZKBlPFNaLQQBzZGPJ73+uXPA==",
       "peer": true,
       "dependencies": {
         "@hookform/resolvers": "^3.9.1",
@@ -430,9 +430,9 @@
       }
     },
     "node_modules/@babylonlabs-io/btc-staking-ts": {
-      "version": "0.4.0-canary.3-test",
-      "resolved": "https://registry.npmjs.org/@babylonlabs-io/btc-staking-ts/-/btc-staking-ts-0.4.0-canary.3-test.tgz",
-      "integrity": "sha512-3FOes5cLZeTr961EvwJc2nGwDqXFygM9JDm5YhOQZYZmq1tc2d9F9WR9Xl4r5u/X/ScSt74G+em/UEWfAXq3rw==",
+      "version": "0.4.0-canary.5",
+      "resolved": "https://registry.npmjs.org/@babylonlabs-io/btc-staking-ts/-/btc-staking-ts-0.4.0-canary.5.tgz",
+      "integrity": "sha512-0lXma1rtYf/mu02ITWPBIrZoEOs2LjZZ/+NmcT3dqvLUQREU/sTIEw+pkxHzh09f+I+DmUxWujNs8PBzX/9XqA==",
       "license": "SEE LICENSE IN LICENSE",
       "peer": true,
       "dependencies": {
@@ -902,9 +902,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.0.tgz",
-      "integrity": "sha512-WtKdFM7ls47zkKHFVzMz8opM7LkcsIp9amDUBIAWirg70RM71WRSjdILPsY5Uv1D42ZpUfaPILDlfactHgsRkw==",
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.1.tgz",
+      "integrity": "sha512-rHKbvBIQEe46PUybicWHsWmStdB3fvHi7CKa36Ip6xUqEr61BmGcnrYohXRNswU9zP/okYLXMzIW6D0neeNv6Q==",
       "cpu": [
         "ppc64"
       ],
@@ -919,9 +919,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.0.tgz",
-      "integrity": "sha512-arAtTPo76fJ/ICkXWetLCc9EwEHKaeya4vMrReVlEIUCAUncH7M4bhMQ+M9Vf+FFOZJdTNMXNBrWwW+OXWpSew==",
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.1.tgz",
+      "integrity": "sha512-gKHsqtULVpVfsffGLaU/W4Jx+DLU8BLOQtvBrg+R22tz422VMgBK5moQ/ELDTRPR7Tqt9gLNk13XlvOFinXSzQ==",
       "cpu": [
         "arm"
       ],
@@ -936,9 +936,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.0.tgz",
-      "integrity": "sha512-Vsm497xFM7tTIPYK9bNTYJyF/lsP590Qc1WxJdlB6ljCbdZKU9SY8i7+Iin4kyhV/KV5J2rOKsBQbB77Ab7L/w==",
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.1.tgz",
+      "integrity": "sha512-0jrWbRDWSPNSmt0HDp4qhWHeL69BL3YSSCGlwNn4logcOijz7nLMsHLT1g5Kb9A8T3dCjX+5qekr5zkH+gbqxQ==",
       "cpu": [
         "arm64"
       ],
@@ -953,9 +953,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.0.tgz",
-      "integrity": "sha512-t8GrvnFkiIY7pa7mMgJd7p8p8qqYIz1NYiAoKc75Zyv73L3DZW++oYMSHPRarcotTKuSs6m3hTOa5CKHaS02TQ==",
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.1.tgz",
+      "integrity": "sha512-FafSki3AkovwnU7zSMDyMKP93Fre1E+c7/mVErP46Y+63RiU2fvKekgpMuLkABDGLGahB/DD0PkPm0YAINmH0Q==",
       "cpu": [
         "x64"
       ],
@@ -970,9 +970,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.0.tgz",
-      "integrity": "sha512-CKyDpRbK1hXwv79soeTJNHb5EiG6ct3efd/FTPdzOWdbZZfGhpbcqIpiD0+vwmpu0wTIL97ZRPZu8vUt46nBSw==",
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.1.tgz",
+      "integrity": "sha512-hJU5uPOQ0SBZ+0OZVx9dkpNyS0Cj1O7sjmqFMeQdp5ATYzCHhMD0CREHgq59eB0AFtCYDBoNcZXNJPwEZ/XDpA==",
       "cpu": [
         "arm64"
       ],
@@ -987,9 +987,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.0.tgz",
-      "integrity": "sha512-rgtz6flkVkh58od4PwTRqxbKH9cOjaXCMZgWD905JOzjFKW+7EiUObfd/Kav+A6Gyud6WZk9w+xu6QLytdi2OA==",
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.1.tgz",
+      "integrity": "sha512-siNAX65WSBKU7c+XJEKByMruE/JsHY9HU+n5BIMiNlo5axVbWwGXN4HhJQzOlY4TtOwSt3LRbS0zuI5SOjgoyg==",
       "cpu": [
         "x64"
       ],
@@ -1004,9 +1004,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.0.tgz",
-      "integrity": "sha512-6Mtdq5nHggwfDNLAHkPlyLBpE5L6hwsuXZX8XNmHno9JuL2+bg2BX5tRkwjyfn6sKbxZTq68suOjgWqCicvPXA==",
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.1.tgz",
+      "integrity": "sha512-Kkl8APGvkp1S1g9tttiicChe49p+A3198sISIVcUGECqDPFXk9hSmVrUmaoCZWKo/zGK9TgLczLRLXduuhLplw==",
       "cpu": [
         "arm64"
       ],
@@ -1021,9 +1021,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.0.tgz",
-      "integrity": "sha512-D3H+xh3/zphoX8ck4S2RxKR6gHlHDXXzOf6f/9dbFt/NRBDIE33+cVa49Kil4WUjxMGW0ZIYBYtaGCa2+OsQwQ==",
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.1.tgz",
+      "integrity": "sha512-7hm+A84yjna/LTVLad+8iG5cB/Ik+M/ekSrN4ALs9GolbwcyvtjSD+xoPhFFAg8D7xVu0JdDIoNNZ6+KWLcPoQ==",
       "cpu": [
         "x64"
       ],
@@ -1038,9 +1038,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.0.tgz",
-      "integrity": "sha512-gJKIi2IjRo5G6Glxb8d3DzYXlxdEj2NlkixPsqePSZMhLudqPhtZ4BUrpIuTjJYXxvF9njql+vRjB2oaC9XpBw==",
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.1.tgz",
+      "integrity": "sha512-USovmgDDpiWs16nRCH/NmRfQUJEaGGDPHqK6+pGzuMZOfoe0MAciJRMu1AKP3Ky4gnpuQcXv7aPHpX0IwLWRhA==",
       "cpu": [
         "arm"
       ],
@@ -1055,9 +1055,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.0.tgz",
-      "integrity": "sha512-TDijPXTOeE3eaMkRYpcy3LarIg13dS9wWHRdwYRnzlwlA370rNdZqbcp0WTyyV/k2zSxfko52+C7jU5F9Tfj1g==",
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.1.tgz",
+      "integrity": "sha512-hjv91wG/3V8oKFa6yAew5wFYc+8usgOL/VH6cNEqFtqpWf8RDmwMIRnTmqwxGJ9/9H5ib3KZfgcIgYwoX7F9VQ==",
       "cpu": [
         "arm64"
       ],
@@ -1072,9 +1072,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.0.tgz",
-      "integrity": "sha512-K40ip1LAcA0byL05TbCQ4yJ4swvnbzHscRmUilrmP9Am7//0UjPreh4lpYzvThT2Quw66MhjG//20mrufm40mA==",
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.1.tgz",
+      "integrity": "sha512-TwspFcPJpYyBqDcoqSLBBaoGRGiPWkjH5V4raiFQ6maAkBho/rfQvtVpNPkLHEwnPlVSdl4HkHZ3n7NvvtU10w==",
       "cpu": [
         "ia32"
       ],
@@ -1089,9 +1089,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.0.tgz",
-      "integrity": "sha512-0mswrYP/9ai+CU0BzBfPMZ8RVm3RGAN/lmOMgW4aFUSOQBjA31UP8Mr6DDhWSuMwj7jaWOT0p0WoZ6jeHhrD7g==",
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.1.tgz",
+      "integrity": "sha512-BS3gcpF33m9hiVFeMCF2+LTdkEr/JljXZGQrlR0Bb7B3pn+uQrAJebclIGar+r8BDJ2yvX9bN4GmMPIKdS20EA==",
       "cpu": [
         "loong64"
       ],
@@ -1106,9 +1106,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.0.tgz",
-      "integrity": "sha512-hIKvXm0/3w/5+RDtCJeXqMZGkI2s4oMUGj3/jM0QzhgIASWrGO5/RlzAzm5nNh/awHE0A19h/CvHQe6FaBNrRA==",
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.1.tgz",
+      "integrity": "sha512-X35vI7EufAX17Nqo6XoD89/HSlPJUB5zJ1UKeTiGOLXpOaz7zo+t1trSQOoq2Gr8usOX++S77VUw6L2wTMc2cA==",
       "cpu": [
         "mips64el"
       ],
@@ -1123,9 +1123,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.0.tgz",
-      "integrity": "sha512-HcZh5BNq0aC52UoocJxaKORfFODWXZxtBaaZNuN3PUX3MoDsChsZqopzi5UupRhPHSEHotoiptqikjN/B77mYQ==",
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.1.tgz",
+      "integrity": "sha512-I+XQCBhTIXKqyLFDcyMP9Dp0u0fx2TiH3BTh4iIg58/a5hmS3l3Yr2AHG8gEsmjUA7WGfKy2ZqxsaVud15iI1w==",
       "cpu": [
         "ppc64"
       ],
@@ -1140,9 +1140,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.0.tgz",
-      "integrity": "sha512-bEh7dMn/h3QxeR2KTy1DUszQjUrIHPZKyO6aN1X4BCnhfYhuQqedHaa5MxSQA/06j3GpiIlFGSsy1c7Gf9padw==",
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.1.tgz",
+      "integrity": "sha512-wK7f0cK/Mq2x42ImYAr+OWzyv4OQUQj/RcKvbxcEoe46LFCa4w08Cqow9zX8vN9SE8BScm4NGYT7CO0G8UBrTA==",
       "cpu": [
         "riscv64"
       ],
@@ -1157,9 +1157,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.0.tgz",
-      "integrity": "sha512-ZcQ6+qRkw1UcZGPyrCiHHkmBaj9SiCD8Oqd556HldP+QlpUIe2Wgn3ehQGVoPOvZvtHm8HPx+bH20c9pvbkX3g==",
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.1.tgz",
+      "integrity": "sha512-47oImRwZavr5qEvEHNPcdly8LuFp3i4xrqT9mNbUn4ZKbwyegVp10k1E1YARiOim8ggfPAPABhPqXdS1NJOAnw==",
       "cpu": [
         "s390x"
       ],
@@ -1174,9 +1174,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.0.tgz",
-      "integrity": "sha512-vbutsFqQ+foy3wSSbmjBXXIJ6PL3scghJoM8zCL142cGaZKAdCZHyf+Bpu/MmX9zT9Q0zFBVKb36Ma5Fzfa8xA==",
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.1.tgz",
+      "integrity": "sha512-8qkGHVK1hH819iH7c9OsQsfUhJ0cgznoGT6vHRNxvNFPhcn0Y7HXLS0ndpY1sUkSM+umIdknz6vEqgPk6pbyIA==",
       "cpu": [
         "x64"
       ],
@@ -1190,10 +1190,27 @@
         "node": ">=18"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.1.tgz",
+      "integrity": "sha512-lH+bWKi8aCvlDu0vDVcZV4ENiHjVus3SQFueeydJ/mSfKywQ3LnbSjJ8PUgj+3dllq1OTFCGgh+x/14hrULVrg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.0.tgz",
-      "integrity": "sha512-hjQ0R/ulkO8fCYFsG0FZoH+pWgTTDreqpqY7UnQntnaKv95uP5iW3+dChxnx7C3trQQU40S+OgWhUVwCjVFLvg==",
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.1.tgz",
+      "integrity": "sha512-OdjqCVKtJuxRk9gPit/iI4/wSCGOnCcuPkgkT8Pt+0vM63QUOBd5oNX2umXUBr4bYTpSCL/aGxrAb3qENcqA4g==",
       "cpu": [
         "x64"
       ],
@@ -1208,9 +1225,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.0.tgz",
-      "integrity": "sha512-MD9uzzkPQbYehwcN583yx3Tu5M8EIoTD+tUgKF982WYL9Pf5rKy9ltgD0eUgs8pvKnmizxjXZyLt0z6DC3rRXg==",
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.1.tgz",
+      "integrity": "sha512-wy2psEw0wc+xbSB4Et3XZaONClCagOlQTsqRJaLtCcPggnuZMfb17c5T5w6RO6pFF5J2SWoM7+MJuWUEzvQN+Q==",
       "cpu": [
         "arm64"
       ],
@@ -1225,9 +1242,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.0.tgz",
-      "integrity": "sha512-4ir0aY1NGUhIC1hdoCzr1+5b43mw99uNwVzhIq1OY3QcEwPDO3B7WNXBzaKY5Nsf1+N11i1eOfFcq+D/gOS15Q==",
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.1.tgz",
+      "integrity": "sha512-GClG42X5JYHoQU5Jry0u+uN2vmKOwrifl10IvDBXtkxyGr9oqOJyrd2U+H2ZoZGNIt21d7WcVJJmJq3I3fl+5g==",
       "cpu": [
         "x64"
       ],
@@ -1242,9 +1259,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.0.tgz",
-      "integrity": "sha512-jVzdzsbM5xrotH+W5f1s+JtUy1UWgjU0Cf4wMvffTB8m6wP5/kx0KiaLHlbJO+dMgtxKV8RQ/JvtlFcdZ1zCPA==",
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.1.tgz",
+      "integrity": "sha512-a0VfBsFPrlFKxzXuJ4nP0ia3jEbzBk/JW2wEW44dwr0RDOr/Y1+d+EJgT6L3h8y9X8ctig7ks0rWlbjkPn6PcA==",
       "cpu": [
         "x64"
       ],
@@ -1259,9 +1276,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.0.tgz",
-      "integrity": "sha512-iKc8GAslzRpBytO2/aN3d2yb2z8XTVfNV0PjGlCxKo5SgWmNXx82I/Q3aG1tFfS+A2igVCY97TJ8tnYwpUWLCA==",
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.1.tgz",
+      "integrity": "sha512-HqeXG1ttUnENzcGlPr0ouQHk8PQIoWi3thXElmafH1pVxC94sYdBVQregb2Qz7l1BmooUIOnzCGPCT4Oma0yTg==",
       "cpu": [
         "arm64"
       ],
@@ -1276,9 +1293,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.0.tgz",
-      "integrity": "sha512-vQW36KZolfIudCcTnaTpmLQ24Ha1RjygBo39/aLkM2kmjkWmZGEJ5Gn9l5/7tzXA42QGIoWbICfg6KLLkIw6yw==",
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.1.tgz",
+      "integrity": "sha512-uA0iNg5jSy9XMiugX8Qtm3p9uUl9hi4JbOY18KnFBNTB+GsfJIWrDpE1cRFZrSHePiZs9cAwnprILpAKJWuYig==",
       "cpu": [
         "ia32"
       ],
@@ -1293,9 +1310,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.0.tgz",
-      "integrity": "sha512-7IAFPrjSQIJrGsK6flwg7NFmwBoSTyF3rl7If0hNUFQU4ilTsEPL6GuMuU9BfIWVVGuRnuIidkSMC+c0Otu8IA==",
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.1.tgz",
+      "integrity": "sha512-wekV0z60AyaD8yYgRtxckqvGzzVaQmQRAhNrR352KzXLfhc4peh3UBMMmtYHbOqml6KblKy7oihC1eaZS68vRw==",
       "cpu": [
         "x64"
       ],
@@ -4434,9 +4451,9 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "18.3.17",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.17.tgz",
-      "integrity": "sha512-opAQ5no6LqJNo9TqnxBKsgnkIYHozW9KSTlFVoSUJYh1Fl/sswkEoqIugRSm7tbh6pABtYjGAjW+GOS23j8qbw==",
+      "version": "18.3.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
+      "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5225,14 +5242,14 @@
       }
     },
     "node_modules/array-buffer-byte-length": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
-      "integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.5",
-        "is-array-buffer": "^3.0.4"
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6538,15 +6555,15 @@
       "license": "MIT"
     },
     "node_modules/data-view-buffer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
-      "integrity": "sha512-0lht7OugA5x3iJLOWFhWK/5ehONdprk0ISXqVFn/NFrDu+cuc8iADFrGQz5BnRK7LLU3JmkbXSxaqX+/mXYtUA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.6",
+        "call-bound": "^1.0.3",
         "es-errors": "^1.3.0",
-        "is-data-view": "^1.0.1"
+        "is-data-view": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6556,21 +6573,21 @@
       }
     },
     "node_modules/data-view-byte-length": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.1.tgz",
-      "integrity": "sha512-4J7wRJD3ABAzr8wP+OcIcqq2dlUKp4DVflx++hs5h5ZKydWMI6/D/fAot+yh6g2tHh8fLFTvNOaVN357NvSrOQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bound": "^1.0.3",
         "es-errors": "^1.3.0",
-        "is-data-view": "^1.0.1"
+        "is-data-view": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "url": "https://github.com/sponsors/inspect-js"
       }
     },
     "node_modules/data-view-byte-offset": {
@@ -6824,9 +6841,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.74",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.74.tgz",
-      "integrity": "sha512-ck3//9RC+6oss/1Bh9tiAVFy5vfSKbRHAFh7Z3/eTRkEqJeWgymloShB17Vg3Z4nmDNp35vAd1BZ6CMW4Wt6Iw==",
+      "version": "1.5.75",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.75.tgz",
+      "integrity": "sha512-Lf3++DumRE/QmweGjU+ZcKqQ+3bKkU/qjaKYhIJKEOhgIO9Xs6IiAQFkfFoj+RhgDk4LUeNsLo6plExHqSyu6Q==",
       "dev": true,
       "license": "ISC"
     },
@@ -7048,9 +7065,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.0.tgz",
-      "integrity": "sha512-FuLPevChGDshgSicjisSooU0cemp/sGXR841D5LHMB7mTVOmsEHcAxaH3irL53+8YDIeVNQEySh4DaYU/iuPqQ==",
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.1.tgz",
+      "integrity": "sha512-bHNW57YAKNh1VSbXP33EL9DevtRuT10czGhL9ynKpOAeBMNAkzsP8FSNoFTbU3abQB7kOb+JqUc89FqlZNbEeQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -7061,30 +7078,31 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.24.0",
-        "@esbuild/android-arm": "0.24.0",
-        "@esbuild/android-arm64": "0.24.0",
-        "@esbuild/android-x64": "0.24.0",
-        "@esbuild/darwin-arm64": "0.24.0",
-        "@esbuild/darwin-x64": "0.24.0",
-        "@esbuild/freebsd-arm64": "0.24.0",
-        "@esbuild/freebsd-x64": "0.24.0",
-        "@esbuild/linux-arm": "0.24.0",
-        "@esbuild/linux-arm64": "0.24.0",
-        "@esbuild/linux-ia32": "0.24.0",
-        "@esbuild/linux-loong64": "0.24.0",
-        "@esbuild/linux-mips64el": "0.24.0",
-        "@esbuild/linux-ppc64": "0.24.0",
-        "@esbuild/linux-riscv64": "0.24.0",
-        "@esbuild/linux-s390x": "0.24.0",
-        "@esbuild/linux-x64": "0.24.0",
-        "@esbuild/netbsd-x64": "0.24.0",
-        "@esbuild/openbsd-arm64": "0.24.0",
-        "@esbuild/openbsd-x64": "0.24.0",
-        "@esbuild/sunos-x64": "0.24.0",
-        "@esbuild/win32-arm64": "0.24.0",
-        "@esbuild/win32-ia32": "0.24.0",
-        "@esbuild/win32-x64": "0.24.0"
+        "@esbuild/aix-ppc64": "0.24.1",
+        "@esbuild/android-arm": "0.24.1",
+        "@esbuild/android-arm64": "0.24.1",
+        "@esbuild/android-x64": "0.24.1",
+        "@esbuild/darwin-arm64": "0.24.1",
+        "@esbuild/darwin-x64": "0.24.1",
+        "@esbuild/freebsd-arm64": "0.24.1",
+        "@esbuild/freebsd-x64": "0.24.1",
+        "@esbuild/linux-arm": "0.24.1",
+        "@esbuild/linux-arm64": "0.24.1",
+        "@esbuild/linux-ia32": "0.24.1",
+        "@esbuild/linux-loong64": "0.24.1",
+        "@esbuild/linux-mips64el": "0.24.1",
+        "@esbuild/linux-ppc64": "0.24.1",
+        "@esbuild/linux-riscv64": "0.24.1",
+        "@esbuild/linux-s390x": "0.24.1",
+        "@esbuild/linux-x64": "0.24.1",
+        "@esbuild/netbsd-arm64": "0.24.1",
+        "@esbuild/netbsd-x64": "0.24.1",
+        "@esbuild/openbsd-arm64": "0.24.1",
+        "@esbuild/openbsd-x64": "0.24.1",
+        "@esbuild/sunos-x64": "0.24.1",
+        "@esbuild/win32-arm64": "0.24.1",
+        "@esbuild/win32-ia32": "0.24.1",
+        "@esbuild/win32-x64": "0.24.1"
       }
     },
     "node_modules/esbuild-register": {
@@ -7940,13 +7958,14 @@
       }
     },
     "node_modules/function.prototype.name": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.7.tgz",
-      "integrity": "sha512-2g4x+HqTJKM9zcJqBSpjoRmdcPFtJM60J3xJisTQSXBWka5XqyBN/2tNUgma1mztTXyDuUsEtYe5qcs7xYzYQA==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
         "define-properties": "^1.2.1",
         "functions-have-names": "^1.2.3",
         "hasown": "^2.0.2",
@@ -11459,9 +11478,9 @@
       "peer": true
     },
     "node_modules/resolve": {
-      "version": "1.22.9",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.9.tgz",
-      "integrity": "sha512-QxrmX1DzraFIi9PxdG5VkRfRwIgjwyud+z/iBwfRRrVmHc+P9Q7u2lSSpQ6bjr2gy5lrqIiU9vb6iAeGf2400A==",
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11471,6 +11490,9 @@
       },
       "bin": {
         "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   ],
   "peerDependencies": {
     "@babylonlabs-io/bbn-core-ui": "^0.6.1",
-    "@babylonlabs-io/btc-staking-ts": "^0.4.0-canary.5",
+    "@babylonlabs-io/btc-staking-ts": "0.4.0-canary.5",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "tailwind-merge": "^2.5.4"

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "@bitcoin-js/tiny-secp256k1-asmjs": "^2.2.3",
     "@cosmjs/stargate": "^0.32.4",
     "@keplr-wallet/types": "^0.12.156",
-    "@keystonehq/animated-qr": "^0.8.6",
-    "@keystonehq/keystone-sdk": "^0.4.1",
+    "@keystonehq/animated-qr": "0.10.0",
+    "@keystonehq/keystone-sdk": "0.9.0",
     "@keystonehq/sdk": "0.22.1",
     "buffer": "^6.0.3",
     "nanoevents": "^9.1.0"
@@ -44,6 +44,7 @@
   ],
   "peerDependencies": {
     "@babylonlabs-io/bbn-core-ui": "^0.6.1",
+    "@babylonlabs-io/btc-staking-ts": "^0.4.0-canary.5",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "tailwind-merge": "^2.5.4"
@@ -58,7 +59,6 @@
     "@storybook/react": "^8.4.2",
     "@storybook/react-vite": "^8.4.2",
     "@storybook/test": "^8.4.2",
-    "@types/bitcoinjs-lib": "^5.0.4",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.3",


### PR DESCRIPTION
- Uses ecc lib from `btc-staking-ts`
- Updates keystone deps to latest so `simple-staking` can work once `tomo` updates

Closes #128 