### PR TITLE
feat: Keystone out of external

### DIFF
--- a/.changeset/serious-rabbits-brake.md
+++ b/.changeset/serious-rabbits-brake.md
@@ -1,0 +1,5 @@
+---
+"@babylonlabs-io/bbn-wallet-connect": patch
+---
+
+include keystone sdk in bundle

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@babylonlabs-io/bbn-wallet-connect",
-  "version": "0.1.23",
+  "version": "0.1.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@babylonlabs-io/bbn-wallet-connect",
-      "version": "0.1.23",
+      "version": "0.1.25",
       "dependencies": {
         "@bitcoin-js/tiny-secp256k1-asmjs": "^2.2.3",
         "@cosmjs/stargate": "^0.32.4",
@@ -1748,9 +1748,9 @@
       }
     },
     "node_modules/@keplr-wallet/types": {
-      "version": "0.12.165",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/types/-/types-0.12.165.tgz",
-      "integrity": "sha512-EbLjEzBlwB1WNdIK1OLg35hSXY28+qEP5hrRGU8NsBoo2CdHzKuDaOsSL5hjZ6AVaA/rCujILyRAHn0tb/+frQ==",
+      "version": "0.12.166",
+      "resolved": "https://registry.npmjs.org/@keplr-wallet/types/-/types-0.12.166.tgz",
+      "integrity": "sha512-P3V0gXNx3zX8LgMrYi1XFgCzjzJmcsYW08DnTbQxEdYT4Y/57l5fKiFR6dV+TWngAw0UO6XCLkiMK5gq+L+yXg==",
       "license": "Apache-2.0",
       "dependencies": {
         "long": "^4.0.0"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -32,7 +32,8 @@ export default defineConfig({
         "@cosmjs/stargate",
         "@babylonlabs-io/bbn-core-ui",
         "@keystonehq/animated-qr",
-        "@keystonehq/keystone-sdk",
+        // Issues linking with Next.js
+        // "@keystonehq/keystone-sdk",
         "@keystonehq/sdk",
         "@bitcoin-js/tiny-secp256k1-asmjs",
       ],


### PR DESCRIPTION
Removes Keystone SDK out of `external` vite bundle to solve the issue linking with `simple-staking` Next.js

Supportive ticket for future: https://github.com/babylonlabs-io/bbn-wallet-connect/issues/150