### PR TITLE
fix: GitHub Readme absolute link

### DIFF
--- a/.changeset/angry-spies-guess.md
+++ b/.changeset/angry-spies-guess.md
@@ -1,0 +1,5 @@
+---
+"@babylonlabs-io/bbn-wallet-connect": patch
+---
+
+github readme interfaces absolute link

--- a/.changeset/angry-spies-guess.md
+++ b/.changeset/angry-spies-guess.md
@@ -2,4 +2,4 @@
 "@babylonlabs-io/bbn-wallet-connect": patch
 ---
 
-github readme interfaces absolute link
+readme inline interfaces

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@
 - [Wallet Integration](#wallet-integration)
   - [1. Browser extension wallets](#1-browser-extension-wallets)
   - [2. Mobile wallets](#2-mobile-wallets)
+    - [IBTCProvider](#ibtcprovider)
+    - [IBBNProvider](#ibbnprovider)
 
 The Babylon Wallet Connector repository provides the wallet connection component
 used in the Babylon Staking Dashboard. This component enables the connection of
@@ -81,10 +83,141 @@ Please refer to Tomo's documentation for integration details.
 
 ### 2. Mobile wallets
 
-Full interface definitions can be found here:
+Full interface definitions can be found in
+[src/core/types.ts](src/core/types.ts):
 
-- [IBTCProvider Interface](src/core/types.ts#L140)
-- [IBBNProvider Interface](src/core/types.ts#L223)
+#### IBTCProvider
+
+```ts
+interface IBTCProvider extends IProvider {
+  /**
+   * Connects to the wallet and returns the instance of the wallet provider.
+   * Currently only supports "native segwit" and "taproot" address types.
+   * @returns A promise that resolves to an instance of the wrapper wallet provider in babylon friendly format.
+   * @throws An error if the wallet is not installed or if connection fails.
+   */
+  connectWallet(): Promise<void>;
+
+  /**
+   * Gets the address of the connected wallet.
+   * @returns A promise that resolves to the address of the connected wallet.
+   */
+  getAddress(): Promise<string>;
+
+  /**
+   * Gets the public key of the connected wallet.
+   * @returns A promise that resolves to the public key of the connected wallet.
+   */
+  getPublicKeyHex(): Promise<string>;
+
+  /**
+   * Signs the given PSBT in hex format.
+   * @param psbtHex - The hex string of the unsigned PSBT to sign.
+   * @returns A promise that resolves to the hex string of the signed PSBT.
+   */
+  signPsbt(psbtHex: string): Promise<string>;
+
+  /**
+   * Signs multiple PSBTs in hex format.
+   * @param psbtsHexes - The hex strings of the unsigned PSBTs to sign.
+   * @returns A promise that resolves to an array of hex strings, each representing a signed PSBT.
+   */
+  signPsbts(psbtsHexes: string[]): Promise<string[]>;
+
+  /**
+   * Gets the network of the current account.
+   * @returns A promise that resolves to the network of the current account.
+   */
+  getNetwork(): Promise<Network>;
+
+  /**
+   * Signs a message using the specified signing method.
+   * @param message - The message to sign.
+   * @param type - The signing method to use.
+   * @returns A promise that resolves to the signed message.
+   */
+  signMessage(message: string, type: "ecdsa"): Promise<string>;
+
+  /**
+   * Retrieves the inscriptions for the connected wallet.
+   * @returns A promise that resolves to an array of inscriptions.
+   */
+  getInscriptions(): Promise<InscriptionIdentifier[]>;
+
+  /**
+   * Registers an event listener for the specified event.
+   * At the moment, only the "accountChanged" event is supported.
+   * @param eventName - The name of the event to listen for.
+   * @param callBack - The callback function to be executed when the event occurs.
+   */
+  on(eventName: string, callBack: () => void): void;
+
+  /**
+   * Unregisters an event listener for the specified event.
+   * @param eventName - The name of the event to listen for.
+   * @param callBack - The callback function to be executed when the event occurs.
+   */
+  off(eventName: string, callBack: () => void): void;
+
+  /**
+   * Gets the name of the wallet provider.
+   * @returns A promise that resolves to the name of the wallet provider.
+   */
+  getWalletProviderName(): Promise<string>;
+
+  /**
+   * Gets the icon of the wallet provider.
+   * @returns A promise that resolves to the icon of the wallet provider.
+   */
+  getWalletProviderIcon(): Promise<string>;
+}
+```
+
+#### IBBNProvider
+
+```ts
+export interface IBBNProvider extends IProvider {
+  /**
+   * Connects to the wallet and returns the instance of the wallet provider.
+   * @returns A promise that resolves to an instance of the wrapper wallet provider.
+   * @throws An error if the wallet is not installed or if connection fails.
+   */
+  connectWallet(): Promise<void>;
+
+  /**
+   * Gets the address of the connected wallet.
+   * @returns A promise that resolves to the address of the connected wallet.
+   */
+  getAddress(): Promise<string>;
+
+  /**
+   * Gets the public key of the connected wallet.
+   * @returns A promise that resolves to the public key of the connected wallet.
+   */
+  getPublicKeyHex(): Promise<string>;
+
+  /**
+   * Gets the name of the wallet provider.
+   * @returns A promise that resolves to the name of the wallet provider.
+   */
+  getWalletProviderName(): Promise<string>;
+
+  /**
+   * Gets the icon of the wallet provider.
+   * @returns A promise that resolves to the icon of the wallet provider.
+   */
+  getWalletProviderIcon(): Promise<string>;
+
+  /**
+   * Retrieves an offline signer that supports both Amino and Direct signing methods.
+   * This signer is used for signing transactions offline before broadcasting them to the network.
+   *
+   * @returns {Promise<OfflineAminoSigner & OfflineDirectSigner>} A promise that resolves to a signer supporting both Amino and Direct signing
+   * @throws {Error} If wallet connection is not established or signer cannot be retrieved
+   */
+  getOfflineSigner(): Promise<OfflineAminoSigner & OfflineDirectSigner>;
+}
+```
 
 1. Implement provider interface
 2. Inject into `window` before loading dApp:

--- a/README.md
+++ b/README.md
@@ -84,7 +84,10 @@ Please refer to Tomo's documentation for integration details.
 ### 2. Mobile wallets
 
 Full interface definitions can be found in
-[src/core/types.ts](src/core/types.ts):
+[src/core/types.ts](src/core/types.ts).
+
+Below we outline the interfaces for Bitcoin and Babylon wallets that need to be
+implemented for integration with the Babylon staking app.
 
 #### IBTCProvider
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Please refer to Tomo's documentation for integration details.
 
 Full interface definitions can be found here:
 
-- [IBTCProvider Interface](src/core/types.ts)
+- [IBTCProvider Interface](src/core/types.ts#L140)
 - [IBBNProvider Interface](src/core/types.ts#L223)
 
 1. Implement provider interface

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ Please refer to Tomo's documentation for integration details.
 
 Full interface definitions can be found here:
 
-- [IBTCProvider Interface](https://github.com/babylonlabs-io/bbn-wallet-connect/blob/main/src/core/types.ts#L140)
-- [IBBNProvider Interface](https://github.com/babylonlabs-io/bbn-wallet-connect/blob/main/src/core/types.ts#L223)
+- [IBTCProvider Interface](src/core/types.ts)
+- [IBBNProvider Interface](src/core/types.ts#L223)
 
 1. Implement provider interface
 2. Inject into `window` before loading dApp:

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ Please refer to Tomo's documentation for integration details.
 
 Full interface definitions can be found here:
 
-- [IBTCProvider Interface](../src/core/types.ts#L135)
-- [IBBNProvider Interface](../src/core/types.ts#L218)
+- [IBTCProvider Interface](https://github.com/babylonlabs-io/bbn-wallet-connect/blob/main/src/core/types.ts#L140)
+- [IBBNProvider Interface](https://github.com/babylonlabs-io/bbn-wallet-connect/blob/main/src/core/types.ts#L223)
 
 1. Implement provider interface
 2. Inject into `window` before loading dApp:

--- a/README.md
+++ b/README.md
@@ -9,15 +9,6 @@
 </p>
 <br/>
 
-> ⚠️ **IMPORTANT**: Breaking changes to the wallet methods used by the Babylon
-> web application are likely to cause incompatibility with it or lead to
-> unexpected behavior with severe consequences.
->
-> Please make sure to always maintain backwards compatibility and test
-> thoroughly all changes affecting the methods required by the Babylon web
-> application. If you are unsure about a change, please reach out to the Babylon
-> Labs team.
-
 - [Key Features](#key-features)
 - [Overview](#overview)
 - [Installation](#installation)
@@ -71,6 +62,15 @@ npm run dev
 ```
 
 ## Wallet Integration
+
+> ⚠️ **IMPORTANT**: Breaking changes to the wallet methods used by the Babylon
+> web application are likely to cause incompatibility with it or lead to
+> unexpected behavior with severe consequences.
+>
+> Please make sure to always maintain backwards compatibility and test
+> thoroughly all changes affecting the methods required by the Babylon web
+> application. If you are unsure about a change, please reach out to the Babylon
+> Labs team.
 
 This guide explains how to integrate wallets with the Babylon staking app. The
 dApp supports both Bitcoin and Babylon wallets through two integration paths:


### PR DESCRIPTION
Changes the link to an absolute one, so it's compatible across the devices