### PR TITLE
feat: Remove tiny secp dependency

### DIFF
--- a/.changeset/new-ants-trade.md
+++ b/.changeset/new-ants-trade.md
@@ -1,0 +1,5 @@
+---
+"@babylonlabs-io/bbn-wallet-connect": patch
+---
+
+remove tiny secp dependency

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,13 @@
 {
   "name": "@babylonlabs-io/bbn-wallet-connect",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@babylonlabs-io/bbn-wallet-connect",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "dependencies": {
-        "@bitcoin-js/tiny-secp256k1-asmjs": "^2.2.3",
         "@cosmjs/stargate": "^0.32.4",
         "@keplr-wallet/types": "^0.12.156",
         "@keystonehq/animated-qr": "0.10.0",
@@ -448,6 +447,7 @@
       "resolved": "https://registry.npmjs.org/@bitcoin-js/tiny-secp256k1-asmjs/-/tiny-secp256k1-asmjs-2.2.3.tgz",
       "integrity": "sha512-arFPdEZi9RIiaG76OZswTnAU0KfuiLwGw2VNfD66LKhzlbfOnX1o1WI/GI3qm9UbjG/0QOzZu/KmTNvL79x/DQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "uint8array-tools": "0.0.7"
       },
@@ -12864,6 +12864,7 @@
       "resolved": "https://registry.npmjs.org/uint8array-tools/-/uint8array-tools-0.0.7.tgz",
       "integrity": "sha512-vrrNZJiusLWoFWBqz5Y5KMCgP9W9hnjZHzZiZRT8oNAkq3d5Z5Oe76jAvVVSRh4U8GGR90N2X1dWtrhvx6L8UQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "release": "npm run build && changeset publish"
   },
   "dependencies": {
-    "@bitcoin-js/tiny-secp256k1-asmjs": "^2.2.3",
     "@cosmjs/stargate": "^0.32.4",
     "@keplr-wallet/types": "^0.12.156",
     "@keystonehq/animated-qr": "0.10.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,7 +35,6 @@ export default defineConfig({
         // Issues linking with Next.js
         // "@keystonehq/keystone-sdk",
         "@keystonehq/sdk",
-        "@bitcoin-js/tiny-secp256k1-asmjs",
       ],
       output: {
         sourcemapExcludeSources: true,


### PR DESCRIPTION
Removes `@bitcoin-js/tiny-secp256k1-asmjs` as not using