### PR TITLE
make connect component mobile compatible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@babylonlabs-io/bbn-wallet-connect",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@babylonlabs-io/bbn-wallet-connect",
-      "version": "0.1.41",
+      "version": "0.1.42",
       "dependencies": {
         "@cosmjs/stargate": "^0.32.4",
         "@keplr-wallet/types": "^0.12.156",
@@ -14,7 +14,8 @@
         "@keystonehq/keystone-sdk": "0.9.0",
         "@keystonehq/sdk": "0.22.1",
         "buffer": "^6.0.3",
-        "nanoevents": "^9.1.0"
+        "nanoevents": "^9.1.0",
+        "usehooks-ts": "^3.0.2"
       },
       "devDependencies": {
         "@changesets/cli": "^2.27.9",
@@ -9433,6 +9434,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -13568,6 +13575,21 @@
       "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/usehooks-ts": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-3.1.0.tgz",
+      "integrity": "sha512-bBIa7yUyPhE1BCc0GmR96VU/15l/9gP1Ch5mYdLcFBaFGQsdmXkvjV0TtOqW1yUd6VjIwDunm+flSciCQXujiw==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.debounce": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=16.15.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0  || ^17 || ^18"
+      }
     },
     "node_modules/util": {
       "version": "0.12.5",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "@keystonehq/keystone-sdk": "0.9.0",
     "@keystonehq/sdk": "0.22.1",
     "buffer": "^6.0.3",
-    "nanoevents": "^9.1.0"
+    "nanoevents": "^9.1.0",
+    "usehooks-ts": "^3.0.2"
   },
   "files": [
     "dist"

--- a/src/components/ResponsiveDialog/ResponsiveDialog.tsx
+++ b/src/components/ResponsiveDialog/ResponsiveDialog.tsx
@@ -1,0 +1,10 @@
+import { Dialog, DialogProps, MobileDialog } from "@babylonlabs-io/bbn-core-ui";
+
+import { useIsMobileView } from "@/hooks/useIsMobileView";
+
+export function ResponsiveDialog(props: DialogProps) {
+  const isMobileView = useIsMobileView();
+  const DialogComponent = isMobileView ? MobileDialog : Dialog;
+
+  return <DialogComponent {...props} />;
+}

--- a/src/components/WalletProvider/components/Screen.tsx
+++ b/src/components/WalletProvider/components/Screen.tsx
@@ -31,7 +31,9 @@ const SCREENS = {
   WALLETS: ({ className, widgets, onClose, onSelectWallet }: ScreenProps) => (
     <Wallets widgets={widgets} className={className} onClose={onClose} onSelectWallet={onSelectWallet} />
   ),
-  INSCRIPTIONS: ({ onToggleInscriptions }: ScreenProps) => <Inscriptions onSubmit={onToggleInscriptions} />,
+  INSCRIPTIONS: ({ className, onToggleInscriptions }: ScreenProps) => (
+    <Inscriptions className={className} onSubmit={onToggleInscriptions} />
+  ),
   LOADER: ({ className, current }: ScreenProps) => (
     <LoaderScreen className={className} title={current?.params?.message as string} />
   ),

--- a/src/components/WalletProvider/components/WalletDialog.tsx
+++ b/src/components/WalletProvider/components/WalletDialog.tsx
@@ -1,8 +1,10 @@
-import { Dialog } from "@babylonlabs-io/bbn-core-ui";
 import { useCallback } from "react";
+import { twMerge } from "tailwind-merge";
 
+import { ResponsiveDialog } from "@/components/ResponsiveDialog/ResponsiveDialog";
 import { useChainProviders } from "@/context/Chain.context";
 import { useInscriptionProvider } from "@/context/Inscriptions.context";
+import { useIsMobileView } from "@/hooks/useIsMobileView";
 import { useWalletConnect } from "@/hooks/useWalletConnect";
 import { useWalletConnectors } from "@/hooks/useWalletConnectors";
 import { useWalletWidgets } from "@/hooks/useWalletWidgets";
@@ -24,6 +26,7 @@ export function WalletDialog({ config, onError }: WalletDialogProps) {
   const walletWidgets = useWalletWidgets(connectors, config);
   const { connect, disconnect } = useWalletConnectors(onError);
   const { disconnect: disconnectAll } = useWalletConnect();
+  const isMobileView = useIsMobileView();
 
   const handleToggleInscriptions = useCallback(
     (lockInscriptions: boolean, showAgain: boolean) => {
@@ -45,11 +48,11 @@ export function WalletDialog({ config, onError }: WalletDialogProps) {
   }, [confirm]);
 
   return (
-    <Dialog open={visible} onClose={handleClose}>
+    <ResponsiveDialog open={visible} onClose={handleClose}>
       <Screen
         current={screen}
         widgets={walletWidgets}
-        className="b-size-[600px]"
+        className={twMerge(isMobileView ? "b-max-h-screen b-overflow-auto b-pt-4" : "b-size-[600px]")}
         onClose={handleClose}
         onConfirm={handleConfirm}
         onSelectWallet={connect}
@@ -57,6 +60,6 @@ export function WalletDialog({ config, onError }: WalletDialogProps) {
         onToggleInscriptions={handleToggleInscriptions}
         onDisconnectWallet={disconnect}
       />
-    </Dialog>
+    </ResponsiveDialog>
   );
 }

--- a/src/hooks/useIsMobileView.ts
+++ b/src/hooks/useIsMobileView.ts
@@ -1,0 +1,7 @@
+import { useMediaQuery } from "usehooks-ts";
+
+// Returns true if the viewport is mobile
+export const useIsMobileView = () => {
+  const matches = useMediaQuery(`(max-width: 768px)`);
+  return matches;
+};


### PR DESCRIPTION

https://github.com/user-attachments/assets/f846e2de-f39e-478e-a981-730819ee4db7


Given we don't have much time for this task, I made a lot short-cut here.

To do it properly:
* Move `ResponsiveDialog` to core-ui library so that it can be shared to other libs.
* Move the screen breakpoint to a shared library
* MobileDialog from core-ui needs some rework, it doesn't work well with small mobile size in story book.