### PR TITLE
chore: bump btc-staking-ts to keep the peer dependency version aligne…

### DIFF
--- a/.changeset/breezy-yaks-deliver.md
+++ b/.changeset/breezy-yaks-deliver.md
@@ -1,0 +1,6 @@
+---
+"@babylonlabs-io/wallet-connector": patch
+---
+
+chore: bump btc-staking-ts to keep the peer dependency version aligned. no
+changed to the wallet side

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@babylonlabs-io/wallet-connector",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@babylonlabs-io/wallet-connector",
-      "version": "1.0.12",
+      "version": "1.0.13",
       "dependencies": {
         "@cosmjs/stargate": "^0.32.4",
         "@keplr-wallet/provider-extension": "^0.12.204",
@@ -62,7 +62,7 @@
         "vite-plugin-node-polyfills": "^0.22.0"
       },
       "peerDependencies": {
-        "@babylonlabs-io/btc-staking-ts": "1.0.3",
+        "@babylonlabs-io/btc-staking-ts": "1.0.4",
         "@babylonlabs-io/core-ui": "1.0.0",
         "bitcoinjs-lib": "6.1.5",
         "react": "^18.3.1",
@@ -435,9 +435,9 @@
       "peer": true
     },
     "node_modules/@babylonlabs-io/btc-staking-ts": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@babylonlabs-io/btc-staking-ts/-/btc-staking-ts-1.0.3.tgz",
-      "integrity": "sha512-ytvb8uy3JsvsrpLSjG/LSellCmQGbXfcxnz5NnCf4sczWTqYT9uLgUsBttj6NrUqlgdkYU+6o20u8gEW9/5+eg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@babylonlabs-io/btc-staking-ts/-/btc-staking-ts-1.0.4.tgz",
+      "integrity": "sha512-LmATrGjBUtm4iol1Lj02sd4bWoXasD+xnLSOxXQfFQ4vPWj3p991p6ezsp8e9elSSkkZiCzqTdHyFdZeR4m+pQ==",
       "license": "SEE LICENSE IN LICENSE",
       "peer": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "dist"
   ],
   "peerDependencies": {
-    "@babylonlabs-io/btc-staking-ts": "1.0.3",
+    "@babylonlabs-io/btc-staking-ts": "1.0.4",
     "@babylonlabs-io/core-ui": "1.0.0",
     "bitcoinjs-lib": "6.1.5",
     "react": "^18.3.1",


### PR DESCRIPTION
bump btc-staking-ts to keep the peer dependency version aligned. no changed to the wallet side